### PR TITLE
メッセージ送信機能の非同期通信化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#new-message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData (this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "post",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  })
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,15 +1,40 @@
 $(function(){
+  function buildHTML(message){
+    var html = `<div class="chat-main__message">
+                  <div class="chat-main__message--name">
+                    ${message.user_name}
+                  </div>
+                  <div class="chat-main__message--time">
+                    ${message.created_at}
+                  </div>
+                  <div class="chat-main__message--body">
+                    <p>
+                      ${message.content}
+                    </p>
+                    <img class="chat-main__message--body-image" src="${message.image}" alt="">
+                  </div>
+                </div>`
+    return html;
+  }
   $('#new-message').on('submit', function(e){
     e.preventDefault();
+    $('.submit').removeAttr('data-disable-with');
     var formData = new FormData (this);
     var url = $(this).attr('action')
     $.ajax({
       url: url,
-      type: "post",
+      type: "POST",
       data: formData,
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat-main__message:last').append(html)
+      $('.chat-main__body').animate({scrollTop: $('.chat-main__body')[0].scrollHeight}, 'fast')
+      $('.message').val('')
+      $('#message_image').val('')
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -36,5 +36,8 @@ $(function(){
       $('.message').val('')
       $('#message_image').val('')
     })
+    .fail(function(){
+      alert('error');
+    })
   })
 });

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else
       render :edit
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,8 +22,9 @@ class GroupsController < ApplicationController
   end
 
   def update
+    @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,6 @@ class MessagesController < ApplicationController
     @messages = @group.messages.includes(:user)
   end
 
-
   def create
     @message = @group.messages.new(message_params)
     if @message.save

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+       respond_to do |format|
+         format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+         format.json
+       end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.user_name   @message.user.name
 json.created_at  @message.created_at
 json.content     @message.content
-json.image       @message.image
+json.image       @message.image.url
 

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.user_name   @message.user.name
+json.created_at  @message.created_at
+json.content     @message.content
+json.image       @message.image
+

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,7 +15,7 @@
     = render @messages
   .chat-main__footer
     .form.chat-main__footer-form
-      = form_for [@group, @message] do |f|
+      = form_for [@group, @message], html: {id: 'new-message'} do |f|
         .chat-main__footer-body
           = f.text_field :content, class: 'message', placeholder: 'type a message'
           .chat-file

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,9 +8,9 @@
       = link_to "edit", edit_group_path(params[:group_id]), class: 'chat-main__header--group-edit-btn'
     .chat-main__header--members
       Members:
-      / %i
-      /   - @group_users.each do |group_user|
-      /     = group_user.name
+      %i
+        - @group.users.each do |user|
+          = user.name
   .chat-main__body
     = render @messages
   .chat-main__footer

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# WHAT

以下を実装した。

①:新しいブランチを作成する
②:jsファイルを作成する
③:フォームが送信されたら、イベントが発火するようにする
④:②のイベントが発火したときにAjaxを使用して、messages#createが動くようにする
⑤messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
⑥jbuilderを使用して、作成したメッセージをJSON形式で返す
⑦返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
⑧:⑥で作成したHTMLをメッセージ画面の一番下に追加する
⑨HTMLを追加した分、メッセージ画面を下にスクロールする
⑩非同期に失敗した場合の処理も準備する

# WHY

今までの実装ではコメントの送信機能を実装していたが、コメントを送信するたびに送信画面にリダイレクトしているため、ビューが毎回再描画されていた。
非同期通信を使って、コメントの送信を非同期で行うために今回の機能を実装した。