### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,11 @@
-$(function(){
+$(document).on('turbolinks:load', function() {
 
   function buildHTML(message){
-    var html = `<div class="chat-main__message">
+    var insertImage = '';
+    if (message.image) {
+      insertImage = `<img class="chat-main__message--body-image" src="${message.image}" alt="">`;
+  }
+    var html = `<div class="chat-main__message" data-message-id="${message.id}">
                   <div class="chat-main__message--name">
                     ${message.user_name}
                   </div>
@@ -12,7 +16,7 @@ $(function(){
                     <p>
                       ${message.content}
                     </p>
-                    <img class="chat-main__message--body-image" src="${message.image}" alt="">
+                    ${insertImage}
                   </div>
                 </div>`
     return html;
@@ -41,4 +45,28 @@ $(function(){
       alert('error');
     })
   })
+  var interval = setInterval(function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)) {
+  $.ajax({
+    url: location.href,
+    dataType: 'json'
+  })
+  .done(function(json) {
+    var id = $('.chat-main__message:last').data('messageId');
+    var insertHTML = '';
+    json.messages.forEach(function(message) {
+      if (message.id > id ) {
+        insertHTML += buildHTML(message);
+        $('.chat-main__body').animate({scrollTop: $('.chat-main__body')[0].scrollHeight}, 'fast')
+      }
+    });
+    $('.chat-main__message:last').prepend(insertHTML);
+  })
+  .fail(function(json) {
+    alert('自動更新に失敗しました');
+  })}
+      else {
+      clearInterval(interval);
+      }
+  } , 5000 );
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -47,20 +47,20 @@ $(document).on('turbolinks:load', function() {
   })
   var interval = setInterval(function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)) {
+      var id = $('.chat-main__message:last').data('message-id');
       $.ajax({
         url: location.href,
-        dataType: 'json'
+        data: {
+          lastId: id
+        }
       })
       .done(function(json) {
-        var id = $('.chat-main__message:last').data('messageId');
         var insertHTML = '';
-        json.messages.forEach(function(message) {
-          if (message.id > id ) {
-            insertHTML += buildHTML(message);
+          if (json.id > id ) {
+            insertHTML += buildHTML(json);
             $('.chat-main__body').animate({scrollTop: $('.chat-main__body')[0].scrollHeight}, 'fast')
+            $('.chat-main__messages-list').prepend(insertHTML);
           }
-        });
-        $('.chat-main__message:last').prepend(insertHTML);
       })
       .fail(function(json) {
         alert('自動更新に失敗しました');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -47,26 +47,27 @@ $(document).on('turbolinks:load', function() {
   })
   var interval = setInterval(function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)) {
-  $.ajax({
-    url: location.href,
-    dataType: 'json'
-  })
-  .done(function(json) {
-    var id = $('.chat-main__message:last').data('messageId');
-    var insertHTML = '';
-    json.messages.forEach(function(message) {
-      if (message.id > id ) {
-        insertHTML += buildHTML(message);
-        $('.chat-main__body').animate({scrollTop: $('.chat-main__body')[0].scrollHeight}, 'fast')
-      }
-    });
-    $('.chat-main__message:last').prepend(insertHTML);
-  })
-  .fail(function(json) {
-    alert('自動更新に失敗しました');
-  })}
-      else {
+      $.ajax({
+        url: location.href,
+        dataType: 'json'
+      })
+      .done(function(json) {
+        var id = $('.chat-main__message:last').data('messageId');
+        var insertHTML = '';
+        json.messages.forEach(function(message) {
+          if (message.id > id ) {
+            insertHTML += buildHTML(message);
+            $('.chat-main__body').animate({scrollTop: $('.chat-main__body')[0].scrollHeight}, 'fast')
+          }
+        });
+        $('.chat-main__message:last').prepend(insertHTML);
+      })
+      .fail(function(json) {
+        alert('自動更新に失敗しました');
+      })
+    }
+    else {
       clearInterval(interval);
-      }
+    }
   } , 5000 );
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,10 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,9 @@ class MessagesController < ApplicationController
     @messages = @group.messages.includes(:user)
     respond_to do |format|
       format.html
-      format.json
+      format.json{
+        @new_messages = @messages.where('id > ?', params[:lastId])
+      }
     end
   end
 

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,5 @@
 .chat-main__body--messages-list
-  .chat-main__message
+  .chat-main__message{ "data-message-id": "#{message.id}"}
     .chat-main__message--name
       = message.user.name
     .chat-main__message--time

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name   @message.user.name
 json.created_at  @message.created_at
 json.content     @message.content
 json.image       @message.image.url
+json.id          @message.id

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.messages @messages.each do |message|
+  json.user_name     message.user.name
+  json.created_at    message.created_at
+  json.content       message.content
+  json.image         message.image.url
+  json.id            message.id
+end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,7 +1,10 @@
-json.messages @messages.each do |message|
+@new_messages.each do |message|
   json.user_name     message.user.name
   json.created_at    message.created_at
   json.content       message.content
   json.image         message.image.url
   json.id            message.id
 end
+
+
+


### PR DESCRIPTION
# WHAT
・チャット画面が自動で更新されるようにする
①定期的に非同期通信を行い、該当グループのメッセージを取得する
②取得したメッセージでメッセージのHTMLを組み立てる
③ビューに追加する

# WHY
ChatSpaceでメッセージ画面が自動で更新されることで、自分以外のユーザーが送信したメッセージも更新時に表示されるようにするため。